### PR TITLE
bugfix: deno assumes relative path for worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,12 @@ interface Schema {
 const db = new CasualDB<Schema>();
 ```
 
-Note: When running via deno, this module will require you to pass the following flags:-
+Note: When running via deno, this module will require you to pass the following flags (all flags are mandatory):-
 
 * `--allow-read` : in order to be able to **read** the JSON files
-* `--allow-write`: in order to be able to **read** the JSON files
+* `--allow-write`: in order to be able to **write** to the JSON files
 * `--unstable`   : this module uses the experimental Worker API in deno, and hence requires this flag
+* `--allow-net`   : this is to enable to download of the Worker file.
 
 If you want to always run the latest code (from the `master` branch) of this module, install via:
 ```ts

--- a/connector.ts
+++ b/connector.ts
@@ -8,12 +8,11 @@ export interface ConnectOptions {
 
 const getNow = Date.now;
 
-const __dirname = path.dirname(path.fromFileUrl(import.meta.url));
 
 export class Connector<Schema = any> {
   private _filePath: string = "";
   private readonly WRITE_TIMEOUT: number = 10000;
-  private readonly WRITE_WORKER_PATH: string = `${__dirname}/writeWorker.ts`;
+  private readonly WRITE_WORKER_PATH: string = new URL('./writeWorker.ts', import.meta.url).href;
   private readonly WRITE_WORKER_OPTIONS: { type: "module"; deno: boolean } = {
     type: "module",
     deno: true,
@@ -35,7 +34,7 @@ export class Connector<Schema = any> {
   }
 
   async connect(fsPath: string, options?: ConnectOptions): Promise<void> {
-    console.log({ workerPath: this.WRITE_WORKER_PATH, dirname: __dirname });
+    console.log({ workerPath: this.WRITE_WORKER_PATH, metaurl: import.meta.url });
     try {
       const fileInfo = await Deno.stat(fsPath);
 

--- a/connector.ts
+++ b/connector.ts
@@ -1,4 +1,4 @@
-import * as path from "https://deno.land/std@0.51.0/path/mod.ts";
+import { dirname, join } from "https://deno.land/std@0.54.0/path/mod.ts"
 import { readJson } from "https://deno.land/std/fs/read_json.ts";
 import { writeJson } from "https://deno.land/std/fs/write_json.ts";
 
@@ -12,7 +12,7 @@ const getNow = Date.now;
 export class Connector<Schema = any> {
   private _filePath: string = "";
   private readonly WRITE_TIMEOUT: number = 10000;
-  private readonly WRITE_WORKER_PATH: string = new URL('./writeWorker.ts', import.meta.url).href;
+  private readonly WRITE_WORKER_PATH: string = join(dirname(import.meta.url), "writeWorker.ts");
   private readonly WRITE_WORKER_OPTIONS: { type: "module"; deno: boolean } = {
     type: "module",
     deno: true,

--- a/connector.ts
+++ b/connector.ts
@@ -1,3 +1,4 @@
+import * as path from "https://deno.land/std@0.51.0/path/mod.ts";
 import { readJson } from "https://deno.land/std/fs/read_json.ts";
 import { writeJson } from "https://deno.land/std/fs/write_json.ts";
 
@@ -7,10 +8,12 @@ export interface ConnectOptions {
 
 const getNow = Date.now;
 
+const __dirname = path.dirname(path.fromFileUrl(import.meta.url));
+
 export class Connector<Schema = any> {
   private _filePath: string = "";
   private readonly WRITE_TIMEOUT: number = 10000;
-  private readonly WRITE_WORKER_PATH: string = "./writeWorker.ts";
+  private readonly WRITE_WORKER_PATH: string = `${__dirname}/writeWorker.ts`;
   private readonly WRITE_WORKER_OPTIONS: { type: "module"; deno: boolean } = {
     type: "module",
     deno: true,

--- a/connector.ts
+++ b/connector.ts
@@ -8,7 +8,6 @@ export interface ConnectOptions {
 
 const getNow = Date.now;
 
-
 export class Connector<Schema = any> {
   private _filePath: string = "";
   private readonly WRITE_TIMEOUT: number = 10000;

--- a/connector.ts
+++ b/connector.ts
@@ -33,7 +33,6 @@ export class Connector<Schema = any> {
   }
 
   async connect(fsPath: string, options?: ConnectOptions): Promise<void> {
-    console.log({ workerPath: this.WRITE_WORKER_PATH, metaurl: import.meta.url });
     try {
       const fileInfo = await Deno.stat(fsPath);
 

--- a/connector.ts
+++ b/connector.ts
@@ -35,6 +35,7 @@ export class Connector<Schema = any> {
   }
 
   async connect(fsPath: string, options?: ConnectOptions): Promise<void> {
+    console.log({ workerPath: this.WRITE_WORKER_PATH, dirname: __dirname });
     try {
       const fileInfo = await Deno.stat(fsPath);
 
@@ -79,7 +80,10 @@ export class Connector<Schema = any> {
         } else if (error) {
           reject(error);
         } else {
-          console.debug("[casualdb:connector:debug]", { returnedTaskId, taskId, error });
+          console.debug(
+            "[casualdb:connector:debug]",
+            { returnedTaskId, taskId, error },
+          );
           reject(new Error(`[casualdb] unknown error while writing to file`));
         }
         if (timeout) {

--- a/mod.ts
+++ b/mod.ts
@@ -1,6 +1,8 @@
 import get from "https://deno.land/x/lodash/get.js";
 import set from "https://deno.land/x/lodash/set.js";
 
+import * as worker from './writeWorker.ts';
+
 import { Connector, ConnectOptions } from "./connector.ts";
 import { createNewOperator } from "./operator/utils.ts";
 

--- a/mod.ts
+++ b/mod.ts
@@ -1,8 +1,6 @@
 import get from "https://deno.land/x/lodash/get.js";
 import set from "https://deno.land/x/lodash/set.js";
 
-import * as worker from './writeWorker.ts';
-
 import { Connector, ConnectOptions } from "./connector.ts";
 import { createNewOperator } from "./operator/utils.ts";
 


### PR DESCRIPTION
Looks like Deno resolves the cwd for worker files. This means that Deno looks for `writeWorker.ts` in the consumer's folder rather than `casualdb`.

This PR updates the path for the worker file to be picked up from package's folder rather than the consumers.

## Notes

- https://stackoverflow.com/questions/61829367/node-js-dirname-filename-equivalent-in-deno
- https://github.com/denoland/deno/issues/2745
- https://discord.com/channels/684898665143206084/689420767620104201/719594785756807180