### PR TITLE
fix: remove version number in std

### DIFF
--- a/connector.ts
+++ b/connector.ts
@@ -1,4 +1,4 @@
-import { dirname, join } from "https://deno.land/std@0.54.0/path/mod.ts"
+import { dirname, join } from "https://deno.land/std/path/mod.ts"
 import { readJson } from "https://deno.land/std/fs/read_json.ts";
 import { writeJson } from "https://deno.land/std/fs/write_json.ts";
 


### PR DESCRIPTION
As bugs in https://github.com/campvanilla/casualdb/issues/11 , latest DENO doesn't support 0.54.0 of std.

Fixes #11 